### PR TITLE
Use the connection name for the database builder

### DIFF
--- a/src/BuilderWithPaginationHavingSupport.php
+++ b/src/BuilderWithPaginationHavingSupport.php
@@ -28,7 +28,7 @@ class BuilderWithPaginationHavingSupport extends Builder
                 }
             }
 
-            $countQuery = DB::table(DB::raw('('.$query->toSql().') as x'))->mergeBindings($query);
+            $countQuery = DB::connection($this->getConnection()->getName())->table(DB::raw('('.$query->toSql().') as x'))->mergeBindings($query);
 
             // Using a aggregate here won't work when
             // groups are present because the


### PR DESCRIPTION
I use a different database connection for a lot of my models which is not my default connection.

So I was getting an error because the countQuery inside `BuilderWithPaginationHavingSupport` was trying to access my default connection.

This PR fixes that for me.